### PR TITLE
Fix scheduled workflow token handling

### DIFF
--- a/.github/workflows/notice-daily-check.yml
+++ b/.github/workflows/notice-daily-check.yml
@@ -42,6 +42,7 @@ jobs:
         if: steps.notice_diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/notice-refresh
           delete-branch: true
           commit-message: "chore: refresh NOTICE.md"

--- a/.github/workflows/workbench-import-issues-pr.yml
+++ b/.github/workflows/workbench-import-issues-pr.yml
@@ -81,6 +81,7 @@ jobs:
         if: steps.import_diff.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           branch: codex/workbench-import-issues
           delete-branch: true
           commit-message: "chore: import GitHub issues into workbench items"


### PR DESCRIPTION
Fix the scheduled workflow failures in openai-agents-dotnet.

- Route create-pull-request through WORKBENCH_GITHUB_TOKEN fallback in the NOTICE and work-item import workflows.

Validation: git diff --check.