### PR TITLE
Repair scheduled Workbench synchronization

### DIFF
--- a/.github/workflows/workbench-import-issues-pr.yml
+++ b/.github/workflows/workbench-import-issues-pr.yml
@@ -62,9 +62,9 @@ jobs:
         shell: bash
         run: |
           if [ -x ./.tools/workbench ]; then
-            ./.tools/workbench item sync -- --import-issues
+            ./.tools/workbench sync --items --import-issues
           else
-            dotnet tool run workbench -- item sync -- --import-issues
+            dotnet tool run workbench -- sync --items --import-issues
           fi
 
       - name: Detect imported issue changes

--- a/.github/workflows/workbench-nightly-sync.yml
+++ b/.github/workflows/workbench-nightly-sync.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Run Workbench issue sync (dry-run validation)
         shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           $outDir = "artifacts/workbench/nightly-sync"
           New-Item -ItemType Directory -Path $outDir -Force | Out-Null


### PR DESCRIPTION
## What changed

- use the supported bulk issue-import command
- provide `GITHUB_TOKEN` to the nightly dry-run sync step

## Root cause

The import workflow used an unsupported command shape, while the nightly workflow omitted the token required for GitHub reconciliation.

## Validation

Pinned Workbench help, workflow YAML parsing, and `git diff --check` passed.